### PR TITLE
Add support for Donut Charts

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@
     "external_scripts": [
       "http://cdnjs.cloudflare.com/ajax/libs/jqPlot/1.0.8/jquery.jqplot.min.js",
       "http://cdnjs.cloudflare.com/ajax/libs/jqPlot/1.0.8/plugins/jqplot.pieRenderer.min.js",
+      "http://cdnjs.cloudflare.com/ajax/libs/jqPlot/1.0.8/plugins/jqplot.donutRenderer.min.js",
       "http://cdnjs.cloudflare.com/ajax/libs/jqPlot/1.0.8/plugins/jqplot.barRenderer.min.js",
       "http://cdnjs.cloudflare.com/ajax/libs/jqPlot/1.0.8/plugins/jqplot.categoryAxisRenderer.min.js",
       "http://cdnjs.cloudflare.com/ajax/libs/jqPlot/1.0.8/plugins/jqplot.pointLabels.min.js"


### PR DESCRIPTION
You can generate Donut Charts by calling `renderer:$.jqplot.DonutRenderer` with this patch. Pretty straight forward. Thanks for making on this! 